### PR TITLE
fix: comply with Google AdSense content policy

### DIFF
--- a/src/components/AdSenseAd.vue
+++ b/src/components/AdSenseAd.vue
@@ -41,6 +41,16 @@ export default {
     enabled: {
       type: Boolean,
       default: () => process.env.VUE_APP_ADSENSE_ENABLED === 'true'
+    },
+    // 强制隐藏广告（用于错误页面、404页面等）
+    forceHide: {
+      type: Boolean,
+      default: false
+    },
+    // 要求页面有实质内容才显示广告
+    requireContent: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -73,9 +83,23 @@ export default {
   },
   methods: {
     checkAdDisplay() {
+      // 强制隐藏广告
+      if (this.forceHide) {
+        this.showAd = false
+        console.log('AdSense ad blocked: forceHide prop is true')
+        return
+      }
+      
       // 在开发环境中可以选择不显示广告
       if (process.env.NODE_ENV === 'development' && !this.enabled) {
         this.showAd = false
+        return
+      }
+      
+      // 检查页面是否包含实质内容（Google AdSense 政策要求）
+      if (this.requireContent && !this.hasSubstantialContent()) {
+        this.showAd = false
+        console.log('AdSense ad blocked: page lacks substantial content')
         return
       }
       
@@ -86,6 +110,61 @@ export default {
         // 等待AdSense脚本加载
         this.waitForAdSense()
       }
+    },
+    
+    hasSubstantialContent() {
+      // 检查当前路由是否为内容页面
+      const currentRoute = this.$route.name
+      const contentRoutes = ['home', 'bazi-results', 'astrology-results', 'transit-analysis', 'bazi-results-shared', 'astrology-results-shared']
+      
+      // 明确禁止在这些页面显示广告
+      const prohibitedRoutes = ['error', 'not-found', '404']
+      if (prohibitedRoutes.includes(currentRoute)) {
+        return false
+      }
+      
+      if (!contentRoutes.includes(currentRoute)) {
+        return false
+      }
+      
+      // 对于结果页面，检查是否有实际计算结果
+      if (['bazi-results', 'astrology-results', 'transit-analysis', 'bazi-results-shared', 'astrology-results-shared'].includes(currentRoute)) {
+        const hasResults = this.$store.getters.getCalculationResults || this.$store.getters.getUserData
+        if (!hasResults) {
+          return false
+        }
+      }
+      
+      // 检查页面是否有足够的文本内容
+      if (typeof document !== 'undefined') {
+        const bodyText = document.body.innerText || document.body.textContent || ''
+        const minContentLength = 800 // 提高到800字符确保有足够内容
+        
+        if (bodyText.length < minContentLength) {
+          return false
+        }
+        
+        // 检查是否包含错误页面、导航页面等非实质内容
+        const hasErrorContent = bodyText.includes('エラーが発生しました') || 
+                              bodyText.includes('ページが見つかりません') ||
+                              bodyText.includes('404') ||
+                              bodyText.includes('問題が発生しました') ||
+                              bodyText.includes('星々の中でページが迷子') ||
+                              bodyText.includes('解決方法') ||
+                              bodyText.includes('デバッグ情報')
+        
+        if (hasErrorContent) {
+          return false
+        }
+        
+        // 检查页面URL路径
+        const currentPath = this.$route.path
+        if (currentPath.includes('error') || currentPath.includes('404') || currentPath.includes('not-found')) {
+          return false
+        }
+      }
+      
+      return true
     },
     
     waitForAdSense() {

--- a/src/views/AstrologyResultsPage.vue
+++ b/src/views/AstrologyResultsPage.vue
@@ -370,8 +370,9 @@
       <span>{{ $t(`astrology.tooltips.${showTooltip}`) }}</span>
     </div>
 
-    <!-- 广告位 -->
+    <!-- 广告位 - 只在有完整计算结果时显示 -->
     <AdSenseAd 
+      v-if="calculationResults && calculationResults.astrology"
       :ad-slot="$options.AD_SLOTS.RECTANGLE"
       container-class="rectangle"
     />

--- a/src/views/BaziResultsPage.vue
+++ b/src/views/BaziResultsPage.vue
@@ -182,8 +182,9 @@
       <p>八字命盤を計算中...</p>
     </div>
 
-    <!-- 广告位 -->
+    <!-- 广告位 - 只在有完整计算结果时显示 -->
     <AdSenseAd 
+      v-if="calculationResults && calculationResults.bazi"
       :ad-slot="$options.AD_SLOTS.RECTANGLE"
       container-class="rectangle"
     />

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -146,7 +146,7 @@
       </div>
     </div>
     
-    <!-- 广告位 -->
+    <!-- 广告位 - 主页有实质内容，可以显示 -->
     <AdSenseAd 
       :ad-slot="$options.AD_SLOTS.BANNER"
       container-class="banner"


### PR DESCRIPTION
- Add content detection logic to AdSenseAd component
- Block ads on error pages, 404 pages, and pages without substantial content
- Ensure ads only display on pages with complete calculation results
- Add minimum content length requirement (800 characters)
- Prevent ads on prohibited routes and error-containing pages

🤖 Generated with [Claude Code](https://claude.ai/code)